### PR TITLE
Issue 34

### DIFF
--- a/www/app/Controllers/Config/Main.php
+++ b/www/app/Controllers/Config/Main.php
@@ -646,6 +646,14 @@ class Main extends Controller {
             Url::redirect('config');
         }
 
+        if ($this->_warehouseModel->getLoweringFinalizedDate() == null) {
+            date_default_timezone_set('Etc/UTC');
+        
+            $timestamp = time();
+            $roundedTimestamp = ceil($timestamp / (15 * 60)) * (15 * 60);
+        
+            $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
+        }
 
         $gmData = array();
         

--- a/www/app/Controllers/Config/Main.php
+++ b/www/app/Controllers/Config/Main.php
@@ -648,11 +648,22 @@ class Main extends Controller {
 
         if ($this->_warehouseModel->getLoweringFinalizedDate()['loweringFinalizedOn'] === null) {
             date_default_timezone_set('Etc/UTC');
-        
             $timestamp = time();
             $roundedTimestamp = ceil($timestamp / (15 * 60)) * (15 * 60);
+
+            $loweringEndDate = $this->_warehouseModel->getLoweringEndDate()['loweringEndDate'];
+            if ($loweringEndDate === null) {
+                $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
+
+            }
+            else {
+                $prev_date=strptime($loweringEndDate, "Y/m/d H:i:S")
+                $now_date = getdate($roundedTimestamp);
+                if ($prev_date > $now_date) {
+                    $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
+                }
+            }
         
-            $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
         }
 
         $gmData = array();

--- a/www/app/Controllers/Config/Main.php
+++ b/www/app/Controllers/Config/Main.php
@@ -657,7 +657,7 @@ class Main extends Controller {
 
             }
             else {
-                $prev_date=strptime($loweringEndDate, "Y/m/d H:i:S")
+                $prev_date=strptime($loweringEndDate, "Y/m/d H:i:S");
                 $now_date = getdate($roundedTimestamp);
                 if ($prev_date > $now_date) {
                     $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));

--- a/www/app/Controllers/Config/Main.php
+++ b/www/app/Controllers/Config/Main.php
@@ -646,7 +646,7 @@ class Main extends Controller {
             Url::redirect('config');
         }
 
-        if ($this->_warehouseModel->getLoweringFinalizedDate() == null) {
+        if ($this->_warehouseModel->getLoweringFinalizedDate()['loweringFinalizedOn'] === null) {
             date_default_timezone_set('Etc/UTC');
         
             $timestamp = time();

--- a/www/app/Controllers/Config/Main.php
+++ b/www/app/Controllers/Config/Main.php
@@ -651,19 +651,19 @@ class Main extends Controller {
             $timestamp = time();
             $roundedTimestamp = ceil($timestamp / (15 * 60)) * (15 * 60);
 
-            $loweringEndDate = $this->_warehouseModel->getLoweringEndDate()['loweringEndDate'];
-            if ($loweringEndDate === null) {
+            $loweringEndDate = $this->_warehouseModel->getLoweringEndDate();
+	    
+	    if ($loweringEndDate === "") {
                 $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
-
             }
             else {
-                $prev_date=strptime($loweringEndDate, "Y/m/d H:i:S");
-                $now_date = getdate($roundedTimestamp);
-                if ($prev_date > $now_date) {
-                    $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
-                }
-            }
-        
+                $prev_time = strtotime($loweringEndDate);
+		var_dump($prev_time);
+		var_dump($roundedTimestamp);
+		if ($prev_time > $roundedTimestamp) {
+		    $this->_warehouseModel->setLoweringEndDate(array('value' => date('Y/m/d H:i', $roundedTimestamp)));
+		}
+	    }
         }
 
         $gmData = array();

--- a/www/app/views/Config/main.php
+++ b/www/app/views/Config/main.php
@@ -5,6 +5,8 @@ use Helpers\Session;
 
 $_warehouseModel = new \Models\Warehouse();
 
+var_dump($_warehouseModel->getLoweringEndDate());
+
 ?>
 
     <div class="row">

--- a/www/app/views/Config/main.php
+++ b/www/app/views/Config/main.php
@@ -5,8 +5,6 @@ use Helpers\Session;
 
 $_warehouseModel = new \Models\Warehouse();
 
-var_dump($_warehouseModel->getLoweringEndDate());
-
 ?>
 
     <div class="row">


### PR DESCRIPTION
Added requested functionality described in issue #34.  Finalize lowering will update lowering endDate when run for the first time AND endDate is null or greater then the current date/time.  Calculated endDate is rounded up to the nearest 15 minutes.