### PR TITLE
Fixes incorrect conditional logic for rsync destination

### DIFF
--- a/server/workers/run_cruise_data_transfer.py
+++ b/server/workers/run_cruise_data_transfer.py
@@ -356,7 +356,7 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
             elif transfer_type == 'rsync':
                 extra_args += [f"--password-file={password_file}"]
 
-            dr_dest_dir = f'{tmpdir}/{self.cruise_id}' if ':' and transfer_type != 'rsync' in dest_dir else f'{dest_dir.rstrip("/")}/{self.cruise_id}'
+            dr_dest_dir = f'{tmpdir}/{self.cruise_id}' if ':' in dest_dir else f'{dest_dir.rstrip("/")}/{self.cruise_id}'
             dry_cmd = _build_rsync_command(dry_flags, extra_args, self.cruise_dir, dr_dest_dir, exclude_file)
             if transfer_type == 'ssh' and cdt_cfg.get('sshUseKey') == '0':
                 dry_cmd = ['sshpass', '-p', cdt_cfg['sshPass']] + dry_cmd


### PR DESCRIPTION
Corrects the conditional logic that determines the destination directory for rsync data transfers. The original logic incorrectly included the transfer type in the check for a colon in the destination directory, leading to unexpected behavior. This change ensures that the presence of a colon in the destination directory is the sole determinant.