### PR TITLE
Fix CruiseData transfer stop target selection

### DIFF
--- a/server/workers/stop_job.py
+++ b/server/workers/stop_job.py
@@ -59,12 +59,12 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
 
         cruise_data_transfers = self.ovdm.get_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         cruise_data_transfers = self.ovdm.get_required_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         tasks = self.ovdm.get_tasks()


### PR DESCRIPTION
## Summary

Fixes CruiseData transfer Stop requests selecting a random running transfer.

The Stop controller already submits the selected PID, but the Stop worker previously selected the first transfer with a nonzero PID.

Closes #104.

## Change

Update both CruiseData-transfer lookup branches in `stop_job.py` from:

```python
if cruise_data_transfer['pid'] != 0:
```

to:

```python
if cruise_data_transfer['pid'] == self.job_pid:
```

This makes the behavior consistent with the existing collection-system-transfer lookup.

## Validation

- `python3 -m py_compile server/workers/stop_job.py`
- `git diff --check`
