### PR TITLE
Fix stop_job PID matching for cruise data transfers and tasks

### DIFF
--- a/server/workers/stop_job.py
+++ b/server/workers/stop_job.py
@@ -59,17 +59,17 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
 
         cruise_data_transfers = self.ovdm.get_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         cruise_data_transfers = self.ovdm.get_required_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         tasks = self.ovdm.get_tasks()
         for task in tasks:
-            if task['pid'] != 0:
+            if task['pid'] == self.job_pid:
                 return {'type': 'task', 'id': task['taskID'], 'name': task['name'], 'pid': task['pid']}
 
         return {'type':'unknown'}


### PR DESCRIPTION
## Summary

Fixes #104: Stop_job could terminate a random running job instead of the one requested.

`_get_job_info()` in `stop_job.py` matched collection system transfers by exact PID (`== self.job_pid`), but matched cruise data transfers, required cruise data transfers, **and scheduled tasks** by `pid != 0` — i.e. the first non-idle record of that type, regardless of which PID the Stop request actually specified.

## Change

Apply the same exact-PID-match comparison used for collection system transfers to the three remaining lookup branches:

```python
if cruise_data_transfer['pid'] == self.job_pid:
```
```python
if task['pid'] == self.job_pid:
```

## Relation to #105

#105 already fixes the two cruise-data-transfer branches. This PR includes that same change plus the identical fix for the **tasks** branch, which #105 doesn't touch — a Stop request against one running scheduled task can currently stop a different running task the same way. Maintainers may prefer to merge whichever PR first and close the other, or cherry-pick the tasks-branch fix into #105.

## Validation

- `python3 -m py_compile server/workers/stop_job.py`
- Manual review of all four lookup branches in `_get_job_info()` for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bz8G6fTSffv1pEAQS3KoJW