### PR TITLE
Wildcard lowering-ID in CDT exclude patterns to avoid stale exclusions

### DIFF
--- a/server/workers/run_cruise_data_transfer.py
+++ b/server/workers/run_cruise_data_transfer.py
@@ -86,7 +86,6 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
 
         wh_cfg = self.shipboard_data_warehouse_config
         cdt_cfg = self.cruise_data_transfer
-        lowerings = self.ovdm.get_lowerings() or []
 
         # Exclude OVDM-related files if flag is set
         if cdt_cfg.get('includeOVDMFiles') == 0:
@@ -96,8 +95,10 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                 f"{wh_cfg['md5SummaryMd5Fn']}"
             ])
 
-            for lowering in lowerings:
-                exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, self.ovdm.get_lowering_config_fn())}")
+            # Wildcard the lowering-ID segment so lowerings created after this
+            # exclude list is generated are still covered for the lifetime of
+            # long-running (e.g. rclone) transfers.
+            exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', self.ovdm.get_lowering_config_fn())}")
 
         # Handle excluded collection systems
         ex_cst_ids = cdt_cfg.get('excludedCollectionSystems', '').split(',') if cdt_cfg.get('excludedCollectionSystems') else []
@@ -112,10 +113,13 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                     # Cruise-level exclusion
                     exclude_filterlist.append(f"{dest_dir.replace('{cruiseID}', self.cruise_id)}/**")
                 else:
-                    # Lowering-level exclusions
-                    for lowering in lowerings:
-                        filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', lowering)
-                        exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, filter_path)}/**")
+                    # Lowering-level exclusion. Wildcard the lowering-ID
+                    # segment rather than enumerating currently known
+                    # lowerings, so lowerings created after this exclude list
+                    # is generated are still covered for the lifetime of
+                    # long-running (e.g. rclone) transfers.
+                    filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', '*')
+                    exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', filter_path)}/**")
 
             except Exception as exc:
                 logging.warning("Could not retrieve collection system transfer %s: %s", cst_id, str(exc))
@@ -133,10 +137,13 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                     # Cruise-level exclusion
                     exclude_filterlist.append(f"{dest_dir.replace('{cruiseID}', self.cruise_id)}/**")
                 else:
-                    # Lowering-level exclusions
-                    for lowering in lowerings:
-                        filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', lowering)
-                        exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, filter_path)}/**")
+                    # Lowering-level exclusion. Wildcard the lowering-ID
+                    # segment rather than enumerating currently known
+                    # lowerings, so lowerings created after this exclude list
+                    # is generated are still covered for the lifetime of
+                    # long-running (e.g. rclone) transfers.
+                    filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', '*')
+                    exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', filter_path)}/**")
 
             except Exception as exc:
                 logging.warning("Could not retrieve extra directory %s: %s", ed_id, str(exc))


### PR DESCRIPTION
## Summary

Addresses #103: dynamically generated CruiseData transfer exclusions can go stale mid-transfer because they're built once at transfer start but rclone (unlike rsync) walks the live tree continuously, sometimes over a multi-day transfer.

## Root cause

`build_exclude_filterlist()` generated one explicit exclude entry **per lowering known at transfer start** for lowering-level excluded collection systems, extra directories, and lowering config files:

```python
for lowering in lowerings:
    filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', lowering)
    exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], lowering, filter_path)}/**")
```

A lowering created *after* this snapshot has no corresponding exclude entry, so data placed under it — even matching an excluded lowering-level collection system or extra directory by config — gets transferred by rclone once it reaches that new directory later in the run.

Cruise-level exclusions weren't affected; they already use a subtree wildcard (`dest_dir/**`) that doesn't depend on enumerating lowerings.

## Fix

Replace the per-lowering enumeration with a single wildcard pattern for the lowering-ID path segment, e.g.:

```python
filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', '*')
exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', filter_path)}/**")
```

`*` in rsync/rclone `--exclude-from` filter syntax matches any sequence of non-`/` characters — i.e. any single lowering directory name — so one pattern now covers every lowering, past and future, without needing to know lowering names in advance. Applied consistently to the lowering-level CST branch, the extra-directory branch, and the lowering-config-file exclusion. `self.ovdm.get_lowerings()` is no longer needed for this and was removed.

Verified manually with a mocked worker instance that the generated patterns look like `Lowering_Data/*/CTD/**` instead of one line per lowering.

## Known limitations (not addressed here)

- **Non-ASCII filenames** discovered by the initial `_find_non_ascii_files` scan are still a point-in-time snapshot; a file with a non-ASCII name created after the scan starts still won't be excluded. This can't be solved with a glob pattern — it needs a periodic re-scan or a different mechanism.
- **Data under directories not modeled as OpenVDM lowerings at all** (e.g. the "new vehicle deployments" case mentioned in the issue) won't be caught by any lowering-based exclusion, wildcard or not — that's a configuration-modeling gap rather than a bug in exclusion generation.

Happy to open follow-up issues for either of these if useful.

## Validation

- `python3 -m py_compile server/workers/run_cruise_data_transfer.py`
- `ruff check server/workers/run_cruise_data_transfer.py`
- Manual invocation of `build_exclude_filterlist()` against a mocked worker confirming wildcard output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bz8G6fTSffv1pEAQS3KoJW