### PR TITLE
Release v2.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to OpenVDM are documented here, organized by release tag aga
 
 ---
 
+## [2.15.6] – 2026-09-04
+
+### Fixed
+- Fix `stop_job` selecting the first running cruise data transfer or scheduled task with a nonzero PID instead of the one matching the requested PID, which could stop the wrong job (#104)
+- Fix cruise data transfer exclusion lists going stale during long-running rclone transfers: lowering-level excluded collection systems, extra directories, and lowering config files are now matched with a wildcard on the lowering ID instead of an explicit list of lowerings known at transfer start, so lowerings created mid-transfer are still excluded (#103)
+
+---
+
 ## [2.15.5] – 2026-08-19
 
 ### Fixed

--- a/server/workers/run_cruise_data_transfer.py
+++ b/server/workers/run_cruise_data_transfer.py
@@ -86,7 +86,6 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
 
         wh_cfg = self.shipboard_data_warehouse_config
         cdt_cfg = self.cruise_data_transfer
-        lowerings = self.ovdm.get_lowerings() or []
 
         # Exclude OVDM-related files if flag is set
         if cdt_cfg.get('includeOVDMFiles') == 0:
@@ -96,8 +95,10 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                 f"{wh_cfg['md5SummaryMd5Fn']}"
             ])
 
-            for lowering in lowerings:
-                exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, self.ovdm.get_lowering_config_fn())}")
+            # Wildcard the lowering-ID segment so lowerings created after this
+            # exclude list is generated are still covered for the lifetime of
+            # long-running (e.g. rclone) transfers.
+            exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', self.ovdm.get_lowering_config_fn())}")
 
         # Handle excluded collection systems
         ex_cst_ids = cdt_cfg.get('excludedCollectionSystems', '').split(',') if cdt_cfg.get('excludedCollectionSystems') else []
@@ -112,10 +113,13 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                     # Cruise-level exclusion
                     exclude_filterlist.append(f"{dest_dir.replace('{cruiseID}', self.cruise_id)}/**")
                 else:
-                    # Lowering-level exclusions
-                    for lowering in lowerings:
-                        filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', lowering)
-                        exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, filter_path)}/**")
+                    # Lowering-level exclusion. Wildcard the lowering-ID
+                    # segment rather than enumerating currently known
+                    # lowerings, so lowerings created after this exclude list
+                    # is generated are still covered for the lifetime of
+                    # long-running (e.g. rclone) transfers.
+                    filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', '*')
+                    exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', filter_path)}/**")
 
             except Exception as exc:
                 logging.warning("Could not retrieve collection system transfer %s: %s", cst_id, str(exc))
@@ -133,10 +137,13 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
                     # Cruise-level exclusion
                     exclude_filterlist.append(f"{dest_dir.replace('{cruiseID}', self.cruise_id)}/**")
                 else:
-                    # Lowering-level exclusions
-                    for lowering in lowerings:
-                        filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', lowering)
-                        exclude_filterlist.append(f"{os.path.join(self.shipboard_data_warehouse_config['loweringDataBaseDir'], lowering, filter_path)}/**")
+                    # Lowering-level exclusion. Wildcard the lowering-ID
+                    # segment rather than enumerating currently known
+                    # lowerings, so lowerings created after this exclude list
+                    # is generated are still covered for the lifetime of
+                    # long-running (e.g. rclone) transfers.
+                    filter_path = dest_dir.replace('{cruiseID}', self.cruise_id).replace('{loweringID}', '*')
+                    exclude_filterlist.append(f"{os.path.join(wh_cfg['loweringDataBaseDir'], '*', filter_path)}/**")
 
             except Exception as exc:
                 logging.warning("Could not retrieve extra directory %s: %s", ed_id, str(exc))

--- a/server/workers/stop_job.py
+++ b/server/workers/stop_job.py
@@ -59,17 +59,17 @@ class OVDMGearmanWorker(python3_gearman.GearmanWorker):
 
         cruise_data_transfers = self.ovdm.get_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         cruise_data_transfers = self.ovdm.get_required_cruise_data_transfers()
         for cruise_data_transfer in cruise_data_transfers:
-            if cruise_data_transfer['pid'] != 0:
+            if cruise_data_transfer['pid'] == self.job_pid:
                 return {'type': 'cruiseDataTransfer', 'id': cruise_data_transfer['cruiseDataTransferID'], 'name': cruise_data_transfer['name'], 'pid': cruise_data_transfer['pid']}
 
         tasks = self.ovdm.get_tasks()
         for task in tasks:
-            if task['pid'] != 0:
+            if task['pid'] == self.job_pid:
                 return {'type': 'task', 'id': task['taskID'], 'name': task['name'], 'pid': task['pid']}
 
         return {'type':'unknown'}

--- a/www/app/Core/Config.php.dist
+++ b/www/app/Core/Config.php.dist
@@ -171,7 +171,7 @@ class Config
         /*
          * Optional create a constant for the name of the site.
          */
-        define('SITETITLE', 'Open Vessel Data Management v2.15.5');
+        define('SITETITLE', 'Open Vessel Data Management v2.15.6');
 
         /*
          * Optionall set a site email address.

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvdm",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openvdm",
-      "version": "2.15.5",
+      "version": "2.15.6",
       "license": "MIT",
       "dependencies": {
         "@vectorial1024/leaflet-color-markers": "^2.0.4",

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvdm",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "homepage": "https://github.com/oceandatatools/openvdm",
   "author": "Webb Pinner",
   "description": "Web-based components of OpenVDM. Built on NOVAFramework by David Carr and the SB Admin 2 Bootstrap theme by David Miller",


### PR DESCRIPTION
## Summary

Hotpatch release v2.15.6. Two bug fixes since v2.15.5:

- Fix #104: `stop_job` selected the first running cruise data transfer or scheduled task with a nonzero PID instead of matching the specific PID requested, which could stop the wrong job. Both the cruise-data-transfer branches and the tasks branch now do an exact PID match, consistent with the collection-system-transfer lookup. (#106)
- Fix #103: cruise data transfer exclusion lists could go stale during long-running rclone transfers — lowering-level excluded collection systems, extra directories, and lowering config files are now matched with a wildcard on the lowering ID instead of an explicit list of lowerings known at transfer start, so lowerings created mid-transfer are still excluded. (#107)

## Changes

- `CHANGELOG.md` — new `[2.15.6]` entry
- `www/app/Core/Config.php.dist`, `www/package.json`, `www/package-lock.json` — version bump 2.15.5 → 2.15.6

## Test plan

- [x] `./manage.py test` / `pytest server/` — passes aside from the three documented false-positive pytest collection errors (`test_cst_source`, `test_cdt_destination`, `test_cdt_rclone_destination` — not real pytest tests)
- [x] `ruff check` clean on both changed worker files
- [x] Verified no other stale version-string references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bz8G6fTSffv1pEAQS3KoJW