### PR TITLE
Clarify that files in "Incorrect Filenames Detected" panel are not transferred

### DIFF
--- a/www/app/templates/default/js/welcome.js
+++ b/www/app/templates/default/js/welcome.js
@@ -134,11 +134,13 @@ $(function () {
             if (status === 'success' && data !== null) {
 
                 var errorFilesOutput = '';
+                var errorFilesPresent = false;
                 if (data.length > 0) {
 
                     var i = 0;
                     for (i = 0; i < data.length; i++) {
                         if(data[i].errorFiles.length > 0) {
+                            errorFilesPresent = true;
                             errorFilesOutput += '                   <h5>' + data[i].collectionSystemName + '</h5>';
                             errorFilesOutput += '                   <ul>';
                             var j = 0;
@@ -161,6 +163,7 @@ $(function () {
                     errorFilesOutput = '                   <h5>No Filename Errors Detected</h5>';
                 }
 
+                $('#filenameErrorsPanel').removeClass('panel-default panel-warning').addClass(errorFilesPresent ? 'panel-warning' : 'panel-default');
                 $(errorFilesPanel).html(errorFilesOutput);
             } setTimeout(function () {
                 updateErrorLogSummary(errorFilesPanel);
@@ -273,6 +276,8 @@ $(function () {
             }, 5000);
         });
     }
+
+    $('[data-toggle="tooltip"]').tooltip();
 
     updateErrorLogSummary('#filenameErrors');
     updateShipboardLogSummary('#shipboardTransfers');

--- a/www/app/templates/default/js/welcome.js
+++ b/www/app/templates/default/js/welcome.js
@@ -163,7 +163,7 @@ $(function () {
                     errorFilesOutput = '                   <h5>No Filename Errors Detected</h5>';
                 }
 
-                $('#filenameErrorsPanel').removeClass('panel-default panel-warning').addClass(errorFilesPresent ? 'panel-warning' : 'panel-default');
+                $('#filenameErrorsPanel').removeClass('panel-default panel-danger').addClass(errorFilesPresent ? 'panel-danger' : 'panel-default');
                 $(errorFilesPanel).html(errorFilesOutput);
             } setTimeout(function () {
                 updateErrorLogSummary(errorFilesPanel);

--- a/www/app/views/Welcome/index.php
+++ b/www/app/views/Welcome/index.php
@@ -45,8 +45,19 @@ foreach($data['requiredCruiseDataTransfers'] as $row){
 <?php
     }
 ?>
-        <div class="panel panel-default">
-                <div class="panel-heading">Incorrect Filenames Detected</div>
+        <div class="panel <?php
+    $filenameErrorsPresent = false;
+    if( is_array($data['filenameErrors']) && sizeof($data['filenameErrors']) > 0) {
+        foreach($data['filenameErrors'] as $row) {
+            if(is_array($row->errorFiles) && sizeof($row->errorFiles) > 0) {
+                $filenameErrorsPresent = true;
+                break;
+            }
+        }
+    }
+    echo $filenameErrorsPresent ? 'panel-warning' : 'panel-default';
+?>" id="filenameErrorsPanel">
+                <div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i></div>
                 <div class="panel-body" id="filenameErrors">
 <?php
     $noErrors = True;

--- a/www/app/views/Welcome/index.php
+++ b/www/app/views/Welcome/index.php
@@ -55,9 +55,9 @@ foreach($data['requiredCruiseDataTransfers'] as $row){
             }
         }
     }
-    echo $filenameErrorsPresent ? 'panel-warning' : 'panel-default';
+    echo $filenameErrorsPresent ? 'panel-danger' : 'panel-default';
 ?>" id="filenameErrorsPanel">
-                <div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i></div>
+	<div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i><?php echo $filenameErrorsPresent ? ' THESE FILES WERE NOT TRANSFERRED' : ''; ?></div>
                 <div class="panel-body" id="filenameErrors">
 <?php
     $noErrors = True;


### PR DESCRIPTION
## Summary
- Add a tooltip to the "Incorrect Filenames Detected" panel explaining that listed files did not match the naming pattern for their collection system and were **not** transferred into the cruise data directory.
- Panel now switches to `panel-danger` only when incorrectly named files are actually present (both on initial page load and on each 5s AJAX poll); otherwise it stays `panel-default`.
- When files are present, the panel heading also appends "THESE FILES WERE NOT TRANSFERRED" for extra visibility.

Closes #109

## Test plan
- [x] Load the dashboard with no `_Exclude.log` entries — panel shows `panel-default` styling and no extra heading text.
- [x] Trigger a collection system transfer with a file that fails the include/exclude filter — panel switches to `panel-danger`, heading shows "THESE FILES WERE NOT TRANSFERRED", and the tooltip icon displays the explanatory text on hover.
- [x] Confirm the panel styling updates correctly after the 5s AJAX poll (not just on page load).