### PR TITLE
Release v2.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to OpenVDM are documented here, organized by release tag aga
 
 ---
 
+## [2.15.7] – 2026-09-12
+
+### Fixed
+- Clarify the "Incorrect Filenames Detected" panel: it now switches to a danger-styled panel with a tooltip only when incorrectly named files are actually present, making clear those files were not transferred into the cruise data directory (#109)
+
+---
+
 ## [2.15.6] – 2026-09-04
 
 ### Fixed

--- a/www/app/Core/Config.php.dist
+++ b/www/app/Core/Config.php.dist
@@ -171,7 +171,7 @@ class Config
         /*
          * Optional create a constant for the name of the site.
          */
-        define('SITETITLE', 'Open Vessel Data Management v2.15.6');
+        define('SITETITLE', 'Open Vessel Data Management v2.15.7');
 
         /*
          * Optionall set a site email address.

--- a/www/app/templates/default/js/welcome.js
+++ b/www/app/templates/default/js/welcome.js
@@ -134,11 +134,13 @@ $(function () {
             if (status === 'success' && data !== null) {
 
                 var errorFilesOutput = '';
+                var errorFilesPresent = false;
                 if (data.length > 0) {
 
                     var i = 0;
                     for (i = 0; i < data.length; i++) {
                         if(data[i].errorFiles.length > 0) {
+                            errorFilesPresent = true;
                             errorFilesOutput += '                   <h5>' + data[i].collectionSystemName + '</h5>';
                             errorFilesOutput += '                   <ul>';
                             var j = 0;
@@ -161,6 +163,7 @@ $(function () {
                     errorFilesOutput = '                   <h5>No Filename Errors Detected</h5>';
                 }
 
+                $('#filenameErrorsPanel').removeClass('panel-default panel-warning').addClass(errorFilesPresent ? 'panel-warning' : 'panel-default');
                 $(errorFilesPanel).html(errorFilesOutput);
             } setTimeout(function () {
                 updateErrorLogSummary(errorFilesPanel);
@@ -273,6 +276,8 @@ $(function () {
             }, 5000);
         });
     }
+
+    $('[data-toggle="tooltip"]').tooltip();
 
     updateErrorLogSummary('#filenameErrors');
     updateShipboardLogSummary('#shipboardTransfers');

--- a/www/app/templates/default/js/welcome.js
+++ b/www/app/templates/default/js/welcome.js
@@ -163,7 +163,7 @@ $(function () {
                     errorFilesOutput = '                   <h5>No Filename Errors Detected</h5>';
                 }
 
-                $('#filenameErrorsPanel').removeClass('panel-default panel-warning').addClass(errorFilesPresent ? 'panel-warning' : 'panel-default');
+                $('#filenameErrorsPanel').removeClass('panel-default panel-danger').addClass(errorFilesPresent ? 'panel-danger' : 'panel-default');
                 $(errorFilesPanel).html(errorFilesOutput);
             } setTimeout(function () {
                 updateErrorLogSummary(errorFilesPanel);

--- a/www/app/views/Welcome/index.php
+++ b/www/app/views/Welcome/index.php
@@ -45,8 +45,19 @@ foreach($data['requiredCruiseDataTransfers'] as $row){
 <?php
     }
 ?>
-        <div class="panel panel-default">
-                <div class="panel-heading">Incorrect Filenames Detected</div>
+        <div class="panel <?php
+    $filenameErrorsPresent = false;
+    if( is_array($data['filenameErrors']) && sizeof($data['filenameErrors']) > 0) {
+        foreach($data['filenameErrors'] as $row) {
+            if(is_array($row->errorFiles) && sizeof($row->errorFiles) > 0) {
+                $filenameErrorsPresent = true;
+                break;
+            }
+        }
+    }
+    echo $filenameErrorsPresent ? 'panel-warning' : 'panel-default';
+?>" id="filenameErrorsPanel">
+                <div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i></div>
                 <div class="panel-body" id="filenameErrors">
 <?php
     $noErrors = True;

--- a/www/app/views/Welcome/index.php
+++ b/www/app/views/Welcome/index.php
@@ -55,9 +55,9 @@ foreach($data['requiredCruiseDataTransfers'] as $row){
             }
         }
     }
-    echo $filenameErrorsPresent ? 'panel-warning' : 'panel-default';
+    echo $filenameErrorsPresent ? 'panel-danger' : 'panel-default';
 ?>" id="filenameErrorsPanel">
-                <div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i></div>
+	<div class="panel-heading">Incorrect Filenames Detected <i class="fa fa-question-circle" data-toggle="tooltip" data-placement="right" title="These files do not match the naming pattern configured for their collection system and were NOT transferred into the cruise data directory."></i><?php echo $filenameErrorsPresent ? ' THESE FILES WERE NOT TRANSFERRED' : ''; ?></div>
                 <div class="panel-body" id="filenameErrors">
 <?php
     $noErrors = True;

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvdm",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "openvdm",
-      "version": "2.15.6",
+      "version": "2.15.7",
       "license": "MIT",
       "dependencies": {
         "@vectorial1024/leaflet-color-markers": "^2.0.4",

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvdm",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "homepage": "https://github.com/oceandatatools/openvdm",
   "author": "Webb Pinner",
   "description": "Web-based components of OpenVDM. Built on NOVAFramework by David Carr and the SB Admin 2 Bootstrap theme by David Miller",


### PR DESCRIPTION
## Summary

Hotpatch release v2.15.7. One UI clarification fix since v2.15.6:

- Fix #109: the "Incorrect Filenames Detected" panel on the Welcome page didn't make clear that listed files were **not** transferred into the cruise data directory. The panel now switches to a danger-styled panel (previously warning) with an explanatory tooltip only when incorrectly named files are actually present, and the panel heading calls out that the files were not transferred. (#110)

## Changes

- `CHANGELOG.md` — new `[2.15.7]` entry
- `www/app/Core/Config.php.dist`, `www/package.json`, `www/package-lock.json` — version bump 2.15.6 → 2.15.7

## Test plan

- [x] `pytest server/` — passes aside from the three documented false-positive pytest collection errors (`test_cst_source`, `test_cdt_destination`, `test_cdt_rclone_destination` — not real pytest tests)
- [x] Verified no other stale version-string references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qe4cup5YbfnLGGqQLah5wL